### PR TITLE
More sane 'default' for classPrefix & optional event.preventDefault()

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Constructs the carousel with options.
           dragRadius: 10
         , moveRadius: 20
         , classPrefix: undefined
+        , preventDefault: true  /* Whether to call Event.preventDefault() for all captured events.  
+                                   Set to false if you need carousel items to capture events,
+                                   but you should still call preventDefault() to ensure normal carousel behaviour. */
         , classNames: {
             outer: "carousel"
           , inner: "carousel-inner"

--- a/src/scooch.js
+++ b/src/scooch.js
@@ -129,6 +129,7 @@ Mobify.UI.Scooch = (function($, Utils) {
           , moveRadius: 20
           , animate: true
           , classPrefix: undefined
+          , preventDefault: true
           , classNames: {
                 outer: 'scooch'
               , inner: 'scooch-inner'
@@ -284,7 +285,9 @@ Mobify.UI.Scooch = (function($, Utils) {
             , windowWidth = $(window).width();
 
         function start(e) {
-            if (!has.touch) e.preventDefault();
+            if (!has.touch && self.options.preventDefault) {
+                e.preventDefault();
+            }
 
             dragging = true;
             canceled = false;
@@ -311,8 +314,9 @@ Mobify.UI.Scooch = (function($, Utils) {
 
             if (dragThresholdMet || abs(dx) > abs(dy) && (abs(dx) > dragRadius)) {
                 dragThresholdMet = true;
-                e.preventDefault();
-
+                if (self.options.preventDefault) {
+                    e.preventDefault();
+                }
                 if (lockLeft && (dx < 0)) {
                     dx = dx * (-dragLimit)/(dx - dragLimit);
                 } else if (lockRight && (dx > 0)) {
@@ -350,7 +354,9 @@ Mobify.UI.Scooch = (function($, Utils) {
         }
 
         function click(e) {
-            if (dragThresholdMet) e.preventDefault();
+            if (dragThresholdMet && self.options.preventDefault) {
+                e.preventDefault();
+            }
         }
 
         $inner
@@ -361,7 +367,9 @@ Mobify.UI.Scooch = (function($, Utils) {
             .on('mouseout.scooch', end);
 
         $element.on('click', '[data-slide]', function(e){
-            e.preventDefault();
+            if (self.options.preventDefault) {
+                e.preventDefault();
+            }
             var action = $(this).attr('data-slide')
               , index = parseInt(action, 10);
 


### PR DESCRIPTION
Change 1: since we wanted a blank class prefix I changed the defaults so that the default classPrefix ('m-') is set only when the option is _undefined_, not a blank string.

Change 2: We had a carousel item with controls (embedded Vimeo video); so we needed to allow event defaults.   To maintain correct carousel behaviour we caught the events further down the DOM tree.
