### PR TITLE
Add Event - Clicking on a slide without dragging trigger a slideClick event

### DIFF
--- a/src/scooch.js
+++ b/src/scooch.js
@@ -348,7 +348,12 @@ Mobify.UI.Scooch = (function($, Utils) {
         }
 
         function click(e) {
-            if (dragThresholdMet) e.preventDefault();
+            if (dragThresholdMet) {
+                e.preventDefault();
+            }
+            else {
+                $element.trigger('slideClick');
+            }
         }
 
         $inner


### PR DESCRIPTION
Scooch will now fire an event "slideClick" when a click on a slide is detected. This event will only fire if the click did not become a drag event.
