### PR TITLE
Added namespace to slide data attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ A mobile-first content and image carousel.
       </div>
       <!-- the controls -->
       <div class="m-scooch-controls m-scooch-bulleted">
-        <a href="#" data-slide="prev">Previous</a>
-        <a href="#" data-slide="1" class="m-active">1</a>
-        <a href="#" data-slide="2">2</a>
-        <a href="#" data-slide="3">3</a>
-        <a href="#" data-slide="next">Next</a>
+        <a href="#" data-m-slide="prev">Previous</a>
+        <a href="#" data-m-slide="1" class="m-active">1</a>
+        <a href="#" data-m-slide="2">2</a>
+        <a href="#" data-m-slide="3">3</a>
+        <a href="#" data-m-slide="next">Next</a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -58,8 +58,8 @@
             </div>
           </div>
           <div class="m-scooch-controls">
-            <a href="#" data-slide="prev">&lsaquo; Previous</a>
-            <a href="#" data-slide="next">Next &rsaquo;</a>
+            <a href="#" data-m-slide="prev">&lsaquo; Previous</a>
+            <a href="#" data-m-slide="next">Next &rsaquo;</a>
           </div>
         </div>
 
@@ -84,11 +84,11 @@
             </div>
           </div>
           <div class="m-scooch-controls m-scooch-bulleted">
-            <a href="#" data-slide="1">1</a>
-            <a href="#" data-slide="2">2</a>
-            <a href="#" data-slide="3">3</a>
-            <a href="#" data-slide="4">4</a>
-            <a href="#" data-slide="5">5</a>
+            <a href="#" data-m-slide="1">1</a>
+            <a href="#" data-m-slide="2">2</a>
+            <a href="#" data-m-slide="3">3</a>
+            <a href="#" data-m-slide="4">4</a>
+            <a href="#" data-m-slide="5">5</a>
           </div>
         </div>
 
@@ -113,13 +113,13 @@
                 </div>
             </div>
             <div class="m-scooch-controls m-scooch-pagination">
-                <a href="#" data-slide="prev">Previous</a>
-                <a href="#" data-slide="1">1</a>
-                <a href="#" data-slide="2">2</a>
-                <a href="#" data-slide="3">3</a>
-                <a href="#" data-slide="4">4</a>
-                <a href="#" data-slide="5">5</a>
-                <a href="#" data-slide="next">Next</a>
+                <a href="#" data-m-slide="prev">Previous</a>
+                <a href="#" data-m-slide="1">1</a>
+                <a href="#" data-m-slide="2">2</a>
+                <a href="#" data-m-slide="3">3</a>
+                <a href="#" data-m-slide="4">4</a>
+                <a href="#" data-m-slide="5">5</a>
+                <a href="#" data-m-slide="next">Next</a>
             </div>
         </div>
 
@@ -144,8 +144,8 @@
                 </div>
             </div>
             <div class="m-scooch-controls m-scooch-hud">
-                <a class="m-scooch-prev" href="#" data-slide="prev">Previous</a>
-                <a class="m-scooch-next" href="#" data-slide="next">Next</a>
+                <a class="m-scooch-prev" href="#" data-m-slide="prev">Previous</a>
+                <a class="m-scooch-next" href="#" data-m-slide="next">Next</a>
             </div>
         </div>
 
@@ -176,8 +176,8 @@
                 </div>
             </div>
             <div class="m-scooch-controls">
-                <a href="#" data-slide="prev">&lsaquo; Previous</a>
-                <a href="#" data-slide="next">Next &rsaquo;</a>
+                <a href="#" data-m-slide="prev">&lsaquo; Previous</a>
+                <a href="#" data-m-slide="next">Next &rsaquo;</a>
             </div>
         </div>
 
@@ -221,8 +221,8 @@
                 </div>
             </div>
             <div class="m-scooch-controls">
-                <a href="#" data-slide="prev">&lsaquo; Previous</a>
-                <a href="#" data-slide="next">Next &rsaquo;</a>
+                <a href="#" data-m-slide="prev">&lsaquo; Previous</a>
+                <a href="#" data-m-slide="next">Next &rsaquo;</a>
             </div>
         </div>
 
@@ -263,8 +263,8 @@
                 </div>
             </div>
             <div class="m-scooch-controls">
-                <a href="#" data-slide="prev">&lsaquo; Previous</a>
-                <a href="#" data-slide="next">Next &rsaquo;</a>
+                <a href="#" data-m-slide="prev">&lsaquo; Previous</a>
+                <a href="#" data-m-slide="next">Next &rsaquo;</a>
             </div>
         </div>
 
@@ -308,8 +308,8 @@
                 </div>
             </div>
             <div class="m-scooch-controls">
-                <a href="#" data-slide="prev">&lsaquo; Previous</a>
-                <a href="#" data-slide="next">Next &rsaquo;</a>
+                <a href="#" data-m-slide="prev">&lsaquo; Previous</a>
+                <a href="#" data-m-slide="next">Next &rsaquo;</a>
             </div>
         </div>
 
@@ -354,8 +354,8 @@
                 </div>
             </div>
             <div class="m-scooch-controls">
-                <a href="#" data-slide="prev">&lsaquo; Previous</a>
-                <a href="#" data-slide="next">Next &rsaquo;</a>
+                <a href="#" data-m-slide="prev">&lsaquo; Previous</a>
+                <a href="#" data-m-slide="next">Next &rsaquo;</a>
             </div>
         </div>
 

--- a/src/scooch.js
+++ b/src/scooch.js
@@ -358,9 +358,9 @@ Mobify.UI.Scooch = (function($, Utils) {
             .on('click.scooch', click)
             .on('mouseout.scooch', end);
 
-        $element.on('click', '[data-slide]', function(e){
+        $element.on('click', '[data-m-slide]', function(e){
             e.preventDefault();
-            var action = $(this).attr('data-slide')
+            var action = $(this).attr('data-m-slide')
               , index = parseInt(action, 10);
 
             if (isNaN(index)) {
@@ -374,8 +374,8 @@ Mobify.UI.Scooch = (function($, Utils) {
             self.$items.eq(previousSlide - 1).removeClass(self._getClass('active'));
             self.$items.eq(nextSlide - 1).addClass(self._getClass('active'));
 
-            self.$element.find('[data-slide=\'' + previousSlide + '\']').removeClass(self._getClass('active'));
-            self.$element.find('[data-slide=\'' + nextSlide + '\']').addClass(self._getClass('active'));
+            self.$element.find('[data-m-slide=\'' + previousSlide + '\']').removeClass(self._getClass('active'));
+            self.$element.find('[data-m-slide=\'' + nextSlide + '\']').addClass(self._getClass('active'));
         });
 
         $(window).on('resize orientationchange', function(e) {


### PR DESCRIPTION
Changed the data attribute `slide` to be `m-slide`. This should prevent some conflicts when using other frameworks.

This actually does conflict with the [Angular Bootstrap](http://angular-ui.github.io/bootstrap/), as `data-slide` is a valid directive name and `slide` is a directive in that module. If using Scooch and Angular Bootstrap you'll get compile errors from Angular.
