### PR TITLE
Fix issue#23 by adding translate(0) to scooch items.

### DIFF
--- a/src/scooch.css
+++ b/src/scooch.css
@@ -39,6 +39,11 @@
     .m-scooch  img  {
         -ms-interpolation-mode:  bicubic;  }
 
+/* https://github.com/mobify/scooch/issues/23 */
+.m-scooch .m-item {
+    -webkit-transform: translate(0);
+    transform: translate(0); }
+
 .m-scooch-inner  {
     position:  relative;
     white-space:  nowrap;


### PR DESCRIPTION
Status: **Ready for merge**
Reviewers: **@scalvert @kpeatt**
## Changes
- Fixes #23 by adding transform: translate(0) to items within a scooch
## Upgrade instructions for non-bower users.

For users not using bower to manage their dependencies you should be able to add the following lines

```
.m-scooch .m-item {
    -webkit-transform: translate(0);
    transform: translate(0); }
```

in to the CSS for your site (probably where you style scooch).

Note: You may need to adjust the classes included here to match those used on your site. This CSS assumes scooch markup that looks like this:

```
        <div class="m-scooch">
          <div class="m-scooch-inner">
            <div class="m-item">
                <img src="http://lorempixel.com/300/300/cats/?1">
            </div>
            <div class="m-item">
                <img src="http://lorempixel.com/300/300/cats/?2">
            </div>
          </div>
        </div>
```
## Alternative Fix

There is also an alternative fix, which involves adding an empty event handler to scooch's items which can be used if the CSS fix does not work for you.

```
$('.m-scooch .m-item').on('touchmove', function(e) {
    return true;
});
```
## Related Reading

Link to WebKit bug that causes this issue: https://bugs.webkit.org/show_bug.cgi?id=137313
## Additional Questions?

If there are issues with this fix not resolving the problem on your site please let me know!
