### PR TITLE
Hide arrow controls logic should work for one item in carousel

### DIFF
--- a/src/scooch.js
+++ b/src/scooch.js
@@ -388,15 +388,15 @@
                 self.$element.find('[data-m-slide=\'' + nextSlide + '\']').addClass(self._getClass('active'));
 
                 if (opts.autoHideArrows) { // Hide prev/next arrows when at bounds
+                    self.$element.find('[data-m-slide=prev]').removeClass(self._getClass('inactive'));
+                    self.$element.find('[data-m-slide=next]').removeClass(self._getClass('inactive'));
+
                     if (nextSlide === 1) {
                         self.$element.find('[data-m-slide=prev]').addClass(self._getClass('inactive'));
-                        self.$element.find('[data-m-slide=next]').removeClass(self._getClass('inactive'));
-                    } else if (nextSlide === self._length) {
+                    }
+
+                    if (nextSlide === self._length) {
                         self.$element.find('[data-m-slide=next]').addClass(self._getClass('inactive'));
-                        self.$element.find('[data-m-slide=prev]').removeClass(self._getClass('inactive'));
-                    } else {
-                        self.$element.find('[data-m-slide=prev]').removeClass(self._getClass('inactive'));
-                        self.$element.find('[data-m-slide=next]').removeClass(self._getClass('inactive'));
                     }
                 }
             });


### PR DESCRIPTION
if there's only one item, it's still going to show the next arrow. Look at this logic:
https://github.com/mobify/scooch/blob/95613168b09f45e9b96d21346dee33eb8f17c533/src/scooch.js#L393

"If next slide is 1st slide, remove inactive class from next arrow"

That only works if there's more than 1 slide. I've pushed the branch back with logic that makes more sense to me: remove both inactive classes, then check if we should add the class based on the position afterward. Since JS is synchronous, the class isn't actually removed from the DOM if the next logic adds it back in.