### PR TITLE
CSOPS-1458: Refactor scooch centering

### DIFF
--- a/src/scooch-style.css
+++ b/src/scooch-style.css
@@ -195,6 +195,25 @@
     margin-right: 20px;
 }
 
+/* https://github.com/mobify/scooch/issues/32 */
+/* Styles for non-fluid, centered carousel */
+.m-center.m-scaled:not(.m-fluid) .m-item {
+    -webkit-transform: translate(-50%) scale(0.75);
+    -moz-transform: translate(-50%) scale(0.75);
+    -ms-transform: translate(-50%) scale(0.75);
+    -o-transform: translate(-50%) scale(0.75);
+    transform: translate(-50%) scale(0.75);
+}
+
+.m-center.m-scaled:not(.m-fluid) .m-item.m-active {
+    -webkit-transform: scale(1) translate(-50%);
+    -moz-transform: scale(1) translate(-50%);
+    -ms-transform: scale(1) translate(-50%);
+    -o-transform: scale(1) translate(-50%);
+    transform: scale(1) translate(-50%);
+}
+
+
 /* Fluid Width Photo Carousel
  * .m-scooch.m-fluid.m-scooch-photos
  */

--- a/src/scooch.css
+++ b/src/scooch.css
@@ -79,18 +79,17 @@
         -moz-box-sizing:  border-box;
         -o-box-sizing:  border-box;
         -webkit-box-sizing:  border-box;  }
-    .m-center:not(.m-fluid)  >  .m-scooch-inner  {
-        display:  inline-block;
-        margin-right:  -20000px  !important;
-        margin-left:  0  !important;  }
-        .m-center:not(.m-fluid)  >  .m-scooch-inner  >  *  {
-            position:  relative;
-            left:  -20000px;  }
-        .m-center:not(.m-fluid)  >  .m-scooch-inner  >  *:first-child  {
-            float:  left;
-            margin-right:  20000px;
-            left:  0;  }
-            .m-center:not(.m-fluid)  >  .m-scooch-inner  >  *:first-child:last-child  {
-                margin-right:  0;  }
-        .m-center:not(.m-fluid)  >  .m-scooch-inner  >  *:last-child  {
-            margin-right:  -30000px;  }
+        
+    /* https://github.com/mobify/scooch/issues/32 */
+    /* Styles for non-fluid, centered carousel */
+    .m-center:not(.m-fluid) .m-item:first-child {
+        margin-left: 50%;
+    }
+
+    .m-center:not(.m-fluid) .m-item {
+        -webkit-transform: translate(-50%);
+        -moz-transform: translate(-50%);
+        -ms-transform: translate(-50%);
+        -o-transform: translate(-50%);
+        transform: translate(-50%);
+    }

--- a/src/scooch.js
+++ b/src/scooch.js
@@ -269,7 +269,9 @@
               , startOffset = $start.prop('offsetLeft') + $start.prop('clientWidth') * this._alignment
               , x = Math.round(-(currentOffset - startOffset) + this._offsetDrag);
 
-            Utils.translateX(this.$inner[0], x);
+            if ($current.prop('offsetParent')) {
+                Utils.translateX(this.$inner[0], x);
+            }
 
             this._needsUpdate = false;
         };


### PR DESCRIPTION
Images were missing on Firefox due to the way we handled centering when displaying fixed-width items. It used large negative margins to position the elements. Unfortunately, Firefox would incorrectly calculate the width of .m-scooch-inner because of margin-right: -30000px on the last .m-item. This PR changes how we handle centering fixed-width images, which corrects the bug in Firefox.

Status: Ready for review
Reviewers: @donnielrt @fractaltheory

## GH Tickets:
- https://github.com/mobify/scooch/issues/30

## Changes
- Remove all old styles pertaining to .m-center:not(.m-fluid)
- Set the margin of the first item to 50%
- For all items, transform: translate(-50%)

## Notes
- This is an alternative fix to https://github.com/mobify/scooch/pull/32