### PR TITLE
Update release steps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+node_modules/
+/build
+/examples
+.git/
+.github/
+
+.gitignore
+npm-debug.log
+localConfig.json
+Gruntfile.js
+circle.yml
+localConfig.example.json
+RELEASE.md

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.0.1:
+    - Add .npmignore
+    - Remove S3 publishing steps
 1.0.0:
     - Add `autoplay` option for automatic looping through carousels
     - Add `infinite` option for looping carousels

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,3 @@
-1.0.1:
-    - Add .npmignore
-    - Remove S3 publishing steps
 1.0.0:
     - Add `autoplay` option for automatic looping through carousels
     - Add `infinite` option for looping carousels

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,20 +57,6 @@ module.exports = function(grunt) {
         zip: {
             'build/scooch.zip': ['src/scooch.js', 'src/scooch.css', 'src/scooch-style.css']
         },
-        s3: {
-            key: '<%= localConfig.aws.key %>',
-            secret: '<%= localConfig.aws.secret %>',
-            bucket: '<%= localConfig.aws.bucket %>',
-            access: 'public-read',
-            headers: { 'Cache-Control': 'max-age=1200' },
-            upload: [
-                { // build
-                    src: 'build/*',
-                    dest: 'modules/scooch/<%= pkg.version %>/',
-                    rel: 'build'
-                }
-            ]
-        },
         eslint: {
             prod: {
                 src: lint.targets,
@@ -104,7 +90,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-open');
     grunt.loadNpmTasks('grunt-shell');
     grunt.loadNpmTasks('grunt-zip');
-    grunt.loadNpmTasks('grunt-s3');
     grunt.loadNpmTasks('grunt-clean');
 
     // Default task(s).
@@ -112,6 +97,5 @@ module.exports = function(grunt) {
     grunt.registerTask('lint', ['eslint:prod']);
     grunt.registerTask('serve', ['connect', 'watch']);
     grunt.registerTask('build', ['lint', 'uglify', 'cssmin', 'zip']);
-    grunt.registerTask('publish', ['build', 's3']);
     grunt.registerTask('default', 'build');
 };

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,4 +15,4 @@ Take this checklist and paste it into your release PR. Ensure steps are followed
 - [ ] Publish a new GitHub [release](https://github.com/mobify/adaptivejs/releases) from the new tag.
 - [ ] Merge `master` into `develop`.
 - [ ] Update your local: `git pull`.
-- [ ] Release on S3 and npm: `npm run publish`
+- [ ] Release on npm: `npm publish`

--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
   "bugs": {
     "url": "https://github.com/mobify/scooch/issues"
   },
-  "homepage": "https://github.com/mobify/scooch#readme",
-  "scripts": {
-    "publish": "grunt publish && npm publish"
-  }
+  "homepage": "https://github.com/mobify/scooch#readme"
 }


### PR DESCRIPTION
Reviewers: @jansepar @marlowpayne 

## Changes
- Remove publishing step for S3 as we no longer host scooch on our CDN. We now tell our users to download it using bower, or npm
- Add an .npmignore file so we don't publish everything to npm

## TODOs:
- [ ] +1
- [x] Updated README
- [x] Updated CHANGELOG

## How To Test
- There are no functional changes. This will only affect the release process.
