### PR TITLE
Update the lockRight property on refresh

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.0.1:
+    - Fix to refresh method ensuring right lock is set properly
 1.0.0:
     - Add `autoplay` option for automatic looping through carousels
     - Add `infinite` option for looping carousels

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scooch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A mobile-first JavaScript-driven content and image carousel",
   "license": "MIT",
   "main": "build/scooch.min.js",

--- a/src/scooch.js
+++ b/src/scooch.js
@@ -347,6 +347,7 @@
             /* Call when number of items has changed (e.g. with AJAX) */
             this.$items = this.$inner.children( '.' + this._getClass('item'));
             this._length = this.$items.length;
+            this._lockRight = this.$items.length;
             this.start();
         };
 


### PR DESCRIPTION
Reviewers: @fractaltheory 

This PR resolves an issue discovered when refreshing an existing Scooch carousel --- the `this._lockRight` property was not properly re-set after the number of carousel items changed.

## Changes
- Update `this._lockRight` property on refresh

## TODOs:
- [x] +1
- [x] Updated README
- [x] Updated CHANGELOG

## How To Test
- Initialize a scooch
- Add more items to the scooch
- Call `$('.scooch').scooch('refresh')`
- Make sure you can scroll through all the new items.
